### PR TITLE
macOS命令行版本+Chrome浏览器验证后优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+__pycache__/
+out/

--- a/backend/bilinovel/Editer.py
+++ b/backend/bilinovel/Editer.py
@@ -17,6 +17,8 @@ from concurrent.futures import ThreadPoolExecutor
 from DrissionPage import Chromium, ChromiumOptions
 import tempfile
 
+from .browser import get_browser_path
+
 lock = threading.RLock()
 
 class Editer(object):

--- a/backend/bilinovel/Editer.py
+++ b/backend/bilinovel/Editer.py
@@ -18,6 +18,7 @@ from DrissionPage import Chromium, ChromiumOptions
 import tempfile
 
 from .browser import get_browser_path
+from ..configs import READ_CONTENT_TAG
 
 lock = threading.RLock()
 
@@ -35,7 +36,12 @@ class Editer(object):
         self.color_page_name = '彩页'
         self.html_buffer = dict()
 
-        path = r'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe'  # 请改为你电脑内Chrome可执行文件路径
+        try:
+            # 使用 ChromeDriverManager 自动下载 ChromeDriver
+            path = get_browser_path()
+        except Exception as e:
+            # 请改为你电脑内Chrome可执行文件路径
+            path = r'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe'
         co = ChromiumOptions().set_browser_path(path)
         self.tab = Chromium(co).latest_tab
         
@@ -157,7 +163,7 @@ class Editer(object):
         is_tansfer_rubbish_code = 'woff2' in content_html
         # is_tansfer_rubbish_code = ('font-family: "read"' in content_html)
         bf = BeautifulSoup(content_html, 'html.parser')
-        text_with_head = bf.find('div', {'id': 'TextContent', 'class': 'ads read-content1'}) 
+        text_with_head = bf.find('div', {'id': 'TextContent', 'class': READ_CONTENT_TAG}) 
         
         self.remove_element(text_with_head, id='show-more-images')
         self.remove_element(text_with_head, class_='google-auto-placed ap_container')
@@ -186,7 +192,7 @@ class Editer(object):
                 if text_html[symbol_index-1] != '\n':
                     text_html = text_html[:symbol_index] + '\n' + text_html[symbol_index:]
         
-        text = BeautifulSoup(text_html, 'html.parser').find('div', class_='ads read-content1', id='TextContent')
+        text = BeautifulSoup(text_html, 'html.parser').find('div', class_=READ_CONTENT_TAG, id='TextContent')
    
 
         #删除反爬提示元素

--- a/backend/bilinovel/browser.py
+++ b/backend/bilinovel/browser.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+import platform
+
+def get_browser_path():
+    """自动获取 Chrome 或 Edge 的浏览器可执行文件路径，兼容 Windows/macOS/Linux"""
+    browser_paths = {
+        "Windows": [
+            r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+            r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+            r"C:\Program Files\Microsoft\Edge\Application\msedge.exe",
+            r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
+        ],
+        "Darwin": [  # macOS
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
+        ],
+        "Linux": [
+            "/usr/bin/google-chrome",
+            "/usr/bin/google-chrome-stable",
+            "/usr/bin/microsoft-edge",
+            "/usr/bin/microsoft-edge-stable"
+        ]
+    }
+    
+    system_os = platform.system()
+    
+    # 1. 先尝试 `shutil.which()` 获取可执行路径
+    for browser in ["google-chrome", "google-chrome-stable", "chrome", "msedge", "microsoft-edge"]:
+        path = shutil.which(browser)
+        if path:
+            return path
+
+    # 2. 如果 `shutil.which()` 失败，尝试默认路径
+    for path in browser_paths.get(system_os, []):
+        if shutil.which(path) or os.path.exists(path):
+            return path
+
+    return None

--- a/backend/configs/__init__.py
+++ b/backend/configs/__init__.py
@@ -1,0 +1,1 @@
+from .consts import *

--- a/backend/configs/consts.py
+++ b/backend/configs/consts.py
@@ -1,0 +1,1 @@
+READ_CONTENT_TAG = "read-content2" # 有变化 改为参数


### PR DESCRIPTION
首先感谢作者的工作，目前用macOS系统使用过程中遇到一些问题：
- 使用前需要手动指定浏览器文件位置
- 爬取文字内容时报错None，疑似 `ads read-content1` class tag的问题

因此我这里做了一些修改：1. 将获取浏览器位置封装函数，2. 将该tag写入configs中方便配置。

欢迎后续讨论～